### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [1.2.0] - 2026-06-09
+
+This release adds a user-selectable Nextflow version control to generated
+Open OnDemand apps so older nf-core pipeline releases can run against a
+compatible Nextflow module version.
+
+### Added
+
+- Generated apps now expose a top-level `Nextflow version` control.
+- The form template attempts to discover available Nextflow module versions
+  automatically from `module avail`, avoiding hardcoded version lists when
+  the OOD host can inspect the module tree.
+- Runtime wrapper logic now loads `nextflow/<selected_version>` when the user
+  chooses an explicit version.
+
+### Changed
+
+- The generated form now keeps `bc_email_on_started` and `nextflow_version`
+  in the rendered `form:` order reliably.
+- The `Nextflow version` field defaults to the newest discovered module
+  version instead of a separate `Site default` placeholder.
+- Help text for `Nextflow version` now explains the backward-compatibility use
+  case for older nf-core pipeline releases.
+- `Email when job starts` now appears at the end of the generated form.
+- Top-level styling and icons now apply to both `Nextflow version` and
+  `Email when job starts`.
+
 ## [1.1.0] - 2026-05-14
 
 This release focuses on portability for non-Tufts HPC centers, robustness of
@@ -126,6 +153,7 @@ apps from locally downloaded nf-core pipelines, including the download
 step (`download_nfcore_pipeline.sh`) and the schema-to-form converter
 (`json2ood.py`). No explicit version tag; see git history for details.
 
-[Unreleased]: https://github.com/TuftsRT/nfcore2ood/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/TuftsRT/nfcore2ood/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/TuftsRT/nfcore2ood/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/TuftsRT/nfcore2ood/compare/5d20ce7...v1.1.0
 [1.0.0]: https://github.com/TuftsRT/nfcore2ood/tree/5d20ce7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nf2ood
 
-**Version: 1.1.0** &middot; [CHANGELOG](./CHANGELOG.md)
+**Version: 1.2.0** &middot; [CHANGELOG](./CHANGELOG.md)
 
 `nf2ood` generates Open OnDemand batch-connect apps from locally downloaded
 nf-core pipelines. The repository includes both the download step and the

--- a/json2ood.py
+++ b/json2ood.py
@@ -34,6 +34,8 @@ ALWAYS_INCLUDE_HIDDEN = {"igenomes_base", "igenomes_ignore"}
 PATH_FORMATS = {"file-path", "path", "directory-path"}
 STATIC_FORM_FIELDS = [
     "bc_num_hours",
+    "bc_email_on_started",
+    "nextflow_version",
     "executor",
     "partition",
     "num_cores",

--- a/json2ood.py
+++ b/json2ood.py
@@ -34,7 +34,6 @@ ALWAYS_INCLUDE_HIDDEN = {"igenomes_base", "igenomes_ignore"}
 PATH_FORMATS = {"file-path", "path", "directory-path"}
 STATIC_FORM_FIELDS = [
     "bc_num_hours",
-    "bc_email_on_started",
     "nextflow_version",
     "executor",
     "partition",
@@ -42,7 +41,7 @@ STATIC_FORM_FIELDS = [
     "num_memory",
     "workdir",
 ]
-TRAILING_FORM_FIELDS = ["resume"]
+TRAILING_FORM_FIELDS = ["resume", "bc_email_on_started"]
 
 
 # Values that can appear in a JSON Schema ``default`` or ``enum``.

--- a/nf2ood
+++ b/nf2ood
@@ -7,7 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 readonly SCRIPT_NAME="$(basename "$0")"
-readonly NF2OOD_VERSION="1.1.0"
+readonly NF2OOD_VERSION="1.2.0"
 
 log() {
   printf '[%s] %s\n' "$SCRIPT_NAME" "$*"

--- a/nfcore_ood_template/form.js
+++ b/nfcore_ood_template/form.js
@@ -358,7 +358,7 @@ function isFirstLevelControllerLabel(label) {
 function isAlwaysIconLabel(labelText, fieldKey) {
   if (["nextflowversion", "bcemailonstarted"].includes(fieldKey)) return true;
   const normalized = normalizeLabel(labelText);
-  return /\b(cores?|cpus?|memory|ram|hours?|time|walltime|resume|workdir|working directory)\b/.test(
+  return /\b(nextflow version|email when job starts|cores?|cpus?|memory|ram|hours?|time|walltime|resume|workdir|working directory)\b/.test(
     normalized
   );
 }

--- a/nfcore_ood_template/form.js
+++ b/nfcore_ood_template/form.js
@@ -83,10 +83,14 @@ const ICONS = {
   vial: "fa fa-fw me-2 fas fa-vial",
   puzzle: "fa fa-fw me-2 fas fa-puzzle-piece",
   key: "fa fa-fw me-2 fas fa-key",
+  mail: "fa fa-fw me-2 fas fa-envelope",
+  branch: "fa fa-fw me-2 fas fa-code-branch",
 };
 
 const iconMap = {
   "number of hours": ICONS.clock,
+  "nextflow version": ICONS.branch,
+  "email when job starts": ICONS.mail,
   "working directory": ICONS.folder,
   "number of cores": ICONS.chip,
   "amount of memory (gb)": ICONS.chip,
@@ -351,7 +355,8 @@ function isFirstLevelControllerLabel(label) {
   );
 }
 
-function isAlwaysIconLabel(labelText) {
+function isAlwaysIconLabel(labelText, fieldKey) {
+  if (["nextflowversion", "bcemailonstarted"].includes(fieldKey)) return true;
   const normalized = normalizeLabel(labelText);
   return /\b(cores?|cpus?|memory|ram|hours?|time|walltime|resume|workdir|working directory)\b/.test(
     normalized
@@ -363,7 +368,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const labelText = label.textContent || "";
     const fieldKey = getLabelFieldKey(label);
     const isFirstLevel = isFirstLevelControllerLabel(label);
-    const isCommonOOD = isAlwaysIconLabel(labelText);
+    const isCommonOOD = isAlwaysIconLabel(labelText, fieldKey);
 
     // Icons only for first-level controller fields, plus common OOD resource fields.
     if (!isFirstLevel && !isCommonOOD) {

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -1,3 +1,25 @@
+<%
+require "open3"
+
+nextflow_module_name = "__NF2OOD_MODULE_NAME__".to_s.strip
+nextflow_versions = []
+
+if !nextflow_module_name.empty?
+  begin
+    module_avail_output, = Open3.capture2(
+      "bash", "-lc", "module -t avail #{nextflow_module_name} 2>&1 || true"
+    )
+
+    nextflow_versions = module_avail_output.lines.filter_map do |line|
+      normalized = line.strip.sub(/\s+\(.*\)\z/, "")
+      match = normalized.match(/\A#{Regexp.escape(nextflow_module_name)}\/(.+)\z/)
+      match && match[1]
+    end.uniq
+  rescue StandardError
+    nextflow_versions = []
+  end
+end
+%>
 ---
 cluster: "__NF2OOD_CLUSTER__"
 form_header: |
@@ -30,6 +52,24 @@ attributes:
     checked_value: 1
     unchecked_value: 0
     help: Send an email notification when the Open OnDemand launch job starts.
+
+<% if !nextflow_module_name.empty? && nextflow_versions.any? %>
+  nextflow_version:
+    label: Nextflow version
+    widget: select
+    options:
+      - ["Site default", ""]
+<% nextflow_versions.each do |version| %>
+      - ["<%= version %>", "<%= version %>"]
+<% end %>
+    help: Optional Nextflow module version to load instead of the site default.
+<% elsif !nextflow_module_name.empty? %>
+  nextflow_version:
+    label: Nextflow version
+    widget: text_field
+    required: false
+    help: Optional Nextflow module version suffix, for example `24.10.5`. Leave blank to load the site default module.
+<% end %>
 
 <%= File.read("__NF2OOD_PARTITION_YML__").indent(2) %>
 

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -4,6 +4,16 @@ require "open3"
 nextflow_module_name = "__NF2OOD_MODULE_NAME__".to_s.strip
 nextflow_versions = []
 
+def nextflow_version_sort_key(version)
+  version.scan(/\d+|[A-Za-z]+/).map do |part|
+    if part.match?(/\A\d+\z/)
+      [0, part.to_i]
+    else
+      [1, part.downcase]
+    end
+  end
+end
+
 if !nextflow_module_name.empty?
   begin
     module_avail_output, = Open3.capture2(
@@ -14,7 +24,7 @@ if !nextflow_module_name.empty?
       normalized = line.strip.sub(/\s+\(.*\)\z/, "")
       match = normalized.match(/\A#{Regexp.escape(nextflow_module_name)}\/(.+)\z/)
       match && match[1]
-    end.uniq
+    end.uniq.sort_by { |version| nextflow_version_sort_key(version) }.reverse
   rescue StandardError
     nextflow_versions = []
   end
@@ -58,17 +68,16 @@ attributes:
     label: Nextflow version
     widget: select
     options:
-      - ["Site default", ""]
 <% nextflow_versions.each do |version| %>
       - ["<%= version %>", "<%= version %>"]
 <% end %>
-    help: Optional Nextflow module version to load instead of the site default.
+    help: Use an older Nextflow version when running previous nf-core pipeline releases.
 <% elsif !nextflow_module_name.empty? %>
   nextflow_version:
     label: Nextflow version
     widget: text_field
     required: false
-    help: Optional Nextflow module version suffix, for example `24.10.5`. Leave blank to load the site default module.
+    help: Use an older Nextflow version when running previous nf-core pipeline releases.
 <% end %>
 
 <%= File.read("__NF2OOD_PARTITION_YML__").indent(2) %>

--- a/nfcore_ood_template/template/script.sh.erb
+++ b/nfcore_ood_template/template/script.sh.erb
@@ -33,11 +33,16 @@ container_module="${NF2OOD_CONTAINER_MODULE:-__NF2OOD_CONTAINER_MODULE__}"
 pipeline_root="${NF2OOD_PIPELINE_ROOT:-__NF2OOD_PIPELINE_ROOT__}"
 singularity_cache="${NF2OOD_SINGULARITY_CACHEDIR:-__NF2OOD_SINGULARITY_CACHEDIR__}"
 slurm_profile="${NF2OOD_SLURM_PROFILE:-__NF2OOD_SLURM_PROFILE__}"
+nextflow_version="<%= context.nextflow_version.to_s.strip %>"
 
 if [[ $(type -t module || true) == "function" ]]; then
   module purge
   if [[ -n "${module_name}" ]]; then
-    module load "${module_name}"
+    if [[ -n "${nextflow_version}" ]]; then
+      module load "${module_name}/${nextflow_version}"
+    else
+      module load "${module_name}"
+    fi
   fi
   if [[ -n "${container_module}" ]]; then
     module load "${container_module}"


### PR DESCRIPTION
## Summary
- add selectable Nextflow module versions in generated OOD apps
- refine top-level form styling and ordering for new controls
- bump nf2ood version to 1.2.0 and update changelog

## Notes
- generated forms now preserve static template fields like nextflow_version and bc_email_on_started
- release should be cut from main after this PR is merged