### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [1.3.0] - 2026-06-22
+
+This release simplifies generated Open OnDemand forms and makes Nextflow
+version choices static at generation time rather than hardcoded in the
+template.
+
+### Added
+
+- `nf2ood` now runs `module avail` during app generation and bakes the
+  discovered Nextflow module versions directly into each generated
+  `form.yml.erb`.
+
+### Changed
+
+- Generated forms no longer include header images in `form_header`.
+- The base form template now uses a placeholder for the `Nextflow version`
+  field, which is filled during generation instead of being maintained as a
+  fixed list in the template.
+
 ## [1.2.0] - 2026-06-09
 
 This release adds a user-selectable Nextflow version control to generated
@@ -153,7 +172,8 @@ apps from locally downloaded nf-core pipelines, including the download
 step (`download_nfcore_pipeline.sh`) and the schema-to-form converter
 (`json2ood.py`). No explicit version tag; see git history for details.
 
-[Unreleased]: https://github.com/TuftsRT/nfcore2ood/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/TuftsRT/nfcore2ood/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/TuftsRT/nfcore2ood/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/TuftsRT/nfcore2ood/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/TuftsRT/nfcore2ood/compare/5d20ce7...v1.1.0
 [1.0.0]: https://github.com/TuftsRT/nfcore2ood/tree/5d20ce7

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ Optional flags:
 
 - `-i, --input PATH`: directory containing nf-core pipeline directories.
   Defaults to `$NF2OOD_PIPELINE_ROOT` when unset.
-- `-m, --image-map /path/to/pipeline2image.tsv`: override the default pipeline image map
 - `-s, --subcategory-map /path/to/pipeline2subcategory.tsv`: override the default
   pipeline-to-subcategory map
 - `-p, --pipeline NAME`: only process pipelines matching `NAME` (accepts
@@ -283,8 +282,6 @@ Each generated app directory includes:
 
 ## Current generated behavior
 
-- the form header can show a pipeline image, with `max-width` and `max-height`
-  both set to `600px`
 - the partition field comes from:
   `<%= File.read(NF2OOD_PARTITION_YML).indent(2) %>`
 - the runtime script can load both a workflow module and a container module
@@ -295,15 +292,6 @@ Each generated app directory includes:
 - generated checkbox `data-hide-...-when-un-checked` behavior requires Open
   OnDemand 3.1 or newer
 
-## Image mapping
-
-By default, `nf2ood` uses [`pipeline2image.tsv`](./pipeline2image.tsv)
-when it exists. That file maps pipeline names to header image URLs.
-
-If the TSV file exists but a pipeline is not listed, no image is rendered for
-that app. If the TSV file does not exist, `nf2ood` falls back to a best-effort
-GitHub raw image URL pattern.
-
 ## Subcategory mapping
 
 By default, `nf2ood` uses
@@ -311,7 +299,7 @@ By default, `nf2ood` uses
 file maps pipeline names to Open OnDemand subcategories (`rnaseq`, `genomics`,
 `singlecell`, etc.) used in each generated `manifest.yml`.
 
-Format is the same as the image map:
+Format is a two-column TSV:
 
 ```text
 <pipeline_name>\t<subcategory>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nf2ood
 
-**Version: 1.2.0** &middot; [CHANGELOG](./CHANGELOG.md)
+**Version: 1.3.0** &middot; [CHANGELOG](./CHANGELOG.md)
 
 `nf2ood` generates Open OnDemand batch-connect apps from locally downloaded
 nf-core pipelines. The repository includes both the download step and the

--- a/customize_app.py
+++ b/customize_app.py
@@ -12,17 +12,13 @@ Usage::
     customize_app.py <app_dir>
         --set __PIPELINE_NAME__=nf-core-rnaseq
         --set __PIPELINE_VERSION__=3.18.0
-        [--remove-banner]
 
-``--set`` is repeatable; each value is split on the first ``=``. ``--remove-
-banner`` deletes the ``<!-- NF2OOD_BANNER_START -->...<!-- NF2OOD_BANNER_END -->``
-block in ``form.yml.erb`` (used when no header image URL is available).
+``--set`` is repeatable; each value is split on the first ``=``.
 """
 
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
 
@@ -38,12 +34,6 @@ SUBSTITUTION_TARGETS = (
     "README.md",
 )
 
-BANNER_BLOCK_PATTERN = re.compile(
-    r"\n  <!-- NF2OOD_BANNER_START -->.*?<!-- NF2OOD_BANNER_END -->\n",
-    re.DOTALL,
-)
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("app_dir", help="Generated OOD app directory")
@@ -54,11 +44,6 @@ def parse_args() -> argparse.Namespace:
         default=[],
         metavar="TOKEN=VALUE",
         help="Replace TOKEN with VALUE everywhere in the target files (repeatable).",
-    )
-    parser.add_argument(
-        "--remove-banner",
-        action="store_true",
-        help="Remove the NF2OOD_BANNER_START/END block from form.yml.erb.",
     )
     return parser.parse_args()
 
@@ -75,17 +60,12 @@ def parse_substitutions(items: list[str]) -> dict[str, str]:
     return subs
 
 
-def apply_substitutions(
-    path: Path, subs: dict[str, str], remove_banner: bool
-) -> None:
+def apply_substitutions(path: Path, subs: dict[str, str]) -> None:
     if not path.is_file():
         return
 
     original = path.read_text(encoding="utf-8")
     content = original
-
-    if remove_banner and path.name == "form.yml.erb":
-        content = BANNER_BLOCK_PATTERN.sub("", content)
 
     for token, value in subs.items():
         content = content.replace(token, value)
@@ -109,7 +89,7 @@ def main() -> int:
 
     subs = parse_substitutions(args.substitutions)
     for relative in SUBSTITUTION_TARGETS:
-        apply_substitutions(app_dir / relative, subs, args.remove_banner)
+        apply_substitutions(app_dir / relative, subs)
 
     return 0
 

--- a/nf2ood
+++ b/nf2ood
@@ -231,6 +231,78 @@ lookup_tsv_value() {
   return 1
 }
 
+discover_nextflow_versions() {
+  local module_name=$1
+  [[ -n "$module_name" ]] || return 0
+  [[ -n "$(type -t module || true)" ]] || return 0
+
+  local module_output
+  module_output="$(module -t avail "$module_name" 2>&1 || true)"
+
+  MODULE_OUTPUT="$module_output" python3 - "$module_name" <<'PY'
+import os
+import re
+import sys
+
+module_name = sys.argv[1]
+raw_output = os.environ.get("MODULE_OUTPUT", "")
+seen = set()
+versions = []
+
+for raw_line in raw_output.splitlines():
+    line = raw_line.split("(", 1)[0].strip()
+    match = re.match(rf"^{re.escape(module_name)}/(.+)$", line)
+    if not match:
+        continue
+    version = match.group(1).strip()
+    if not version or version in seen:
+        continue
+    seen.add(version)
+    versions.append(version)
+
+def version_key(value: str):
+    parts = re.findall(r"\d+|[A-Za-z]+", value)
+    key = []
+    for part in parts:
+        if part.isdigit():
+            key.append((0, int(part)))
+        else:
+            key.append((1, part.lower()))
+    return key
+
+for version in sorted(versions, key=version_key, reverse=True):
+    print(version)
+PY
+}
+
+render_nextflow_version_field() {
+  local module_name=$1
+  local -a versions=()
+  mapfile -t versions < <(discover_nextflow_versions "$module_name")
+
+  if (( ${#versions[@]} > 0 )); then
+    printf '%s\n' \
+      '  nextflow_version:' \
+      '    label: Nextflow version' \
+      '    widget: select' \
+      '    options:'
+    local version
+    for version in "${versions[@]}"; do
+      printf '      - ["%s", "%s"]\n' "$version" "$version"
+    done
+    printf '%s\n' \
+      '    help: Use an older Nextflow version when running previous nf-core pipeline releases.'
+    return 0
+  fi
+
+  printf '%s\n' \
+    '  nextflow_version:' \
+    '    label: Nextflow version' \
+    '    widget: text_field' \
+    '    required: false' \
+    '    help: Use an older Nextflow version when running previous nf-core pipeline releases.'
+}
+
 determine_subcategory() {
   local pipeline_name=$1
   local subcategory_map_tsv=${SUBCATEGORY_MAP_TSV:-}
@@ -286,6 +358,8 @@ customize_generated_app() {
   # value here propagates correctly.
   rendered_module_name="${NF2OOD_MODULE_NAME-nextflow}"
   rendered_container_module="${NF2OOD_CONTAINER_MODULE-singularity}"
+  local rendered_nextflow_version_field
+  rendered_nextflow_version_field="$(render_nextflow_version_field "$rendered_module_name")"
 
   # Build the --set TOKEN=VALUE arglist once and apply all substitutions in a
   # single Python pass over the small set of files in the app dir.
@@ -303,6 +377,7 @@ customize_generated_app() {
     --set "__NF2OOD_DEFAULT_DIRECTORY__=${rendered_default_directory}"
     --set "__NF2OOD_PARTITION_YML__=${rendered_partition_partial}"
     --set "__NF2OOD_MODULE_NAME__=${rendered_module_name}"
+    --set "__NEXTFLOW_VERSION_FIELD__=${rendered_nextflow_version_field}"
     --set "__NF2OOD_CONTAINER_MODULE__=${rendered_container_module}"
     --set "__NF2OOD_PIPELINE_ROOT__=${rendered_pipeline_root}"
     --set "__NF2OOD_SINGULARITY_CACHEDIR__=${rendered_singularity_cache}"

--- a/nf2ood
+++ b/nf2ood
@@ -7,7 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 readonly SCRIPT_NAME="$(basename "$0")"
-readonly NF2OOD_VERSION="1.2.0"
+readonly NF2OOD_VERSION="1.3.0"
 
 log() {
   printf '[%s] %s\n' "$SCRIPT_NAME" "$*"

--- a/nf2ood
+++ b/nf2ood
@@ -26,7 +26,7 @@ usage() {
   print_version
   printf '\n'
   cat <<'EOF'
-Usage: nf2ood --output OUTPUT_DIR [--input INPUT_DIR] [--image-map TSV]
+Usage: nf2ood --output OUTPUT_DIR [--input INPUT_DIR]
               [--subcategory-map TSV] [--pipeline NAME] [--version VER]
               [--force] [--dry-run]
 
@@ -40,9 +40,6 @@ Optional arguments:
                          Defaults to ${NF2OOD_PIPELINE_ROOT} when unset, since
                          that is normally where download_nfcore_pipeline.sh
                          installs pipelines for this site.
-  -m, --image-map        TSV mapping of pipeline name to image URL
-                         Format: <pipeline_name>\t<image_url>
-                         Default: ./pipeline2image.tsv when present
   -s, --subcategory-map  TSV mapping of pipeline name to OOD subcategory
                          Format: <pipeline_name>\t<subcategory>
                          Default: ./pipeline2subcategory.tsv when present
@@ -201,41 +198,6 @@ locate_schema() {
   return 1
 }
 
-resolve_pipeline_image_url() {
-  local image_map_tsv=$1
-  local pipeline_name=$2
-  local pipeline_version=$3
-  local pipeline_slug="${pipeline_name#nf-core-}"
-  local normalized_slug
-  normalized_slug="$(printf '%s' "$pipeline_slug" | tr '[:upper:]' '[:lower:]')"
-
-  if [[ -n "$image_map_tsv" && -f "$image_map_tsv" ]]; then
-    local row_key row_url normalized_key
-    while IFS=$'\t' read -r row_key row_url _; do
-      row_key=${row_key//$'\r'/}
-      row_url=${row_url//$'\r'/}
-
-      [[ -z "${row_key//[[:space:]]/}" ]] && continue
-      [[ "${row_key:0:1}" == "#" ]] && continue
-
-      normalized_key="$(printf '%s' "$row_key" | tr '[:upper:]' '[:lower:]')"
-      [[ "$normalized_key" == "pipeline" || "$normalized_key" == "pipeline_name" ]] && continue
-      normalized_key="${normalized_key#nf-core-}"
-
-      if [[ "$normalized_key" == "$normalized_slug" ]]; then
-        printf '%s\n' "$row_url"
-        return 0
-      fi
-    done < "$image_map_tsv"
-
-    printf '\n'
-    return 0
-  fi
-
-  printf 'https://raw.githubusercontent.com/nf-core/%s/%s/docs/images/%s_metro_map.png\n' \
-    "$pipeline_slug" "$pipeline_version" "$pipeline_slug"
-}
-
 lookup_tsv_value() {
   # Look up a key in a 2-column TSV. Comments (#) and blank lines are skipped,
   # as is a header row matching "pipeline" or "pipeline_name". Key match is
@@ -291,17 +253,15 @@ customize_generated_app() {
   local app_dir=$1
   local pipeline_name=$2
   local pipeline_version=$3
-  local image_map_tsv=$4
 
   local pipeline_slug="${pipeline_name#nf-core-}"
-  local app_slug version_path image_url subcategory
+  local app_slug version_path subcategory
   local rendered_cluster rendered_default_directory rendered_module_name
   local rendered_pipeline_root rendered_singularity_cache rendered_slurm_profile
   local rendered_container_module rendered_partition_partial rendered_env_file
 
   app_slug="$(basename "$app_dir")"
   version_path="${pipeline_version}/${pipeline_version//./_}"
-  image_url="$(resolve_pipeline_image_url "$image_map_tsv" "$pipeline_name" "$pipeline_version")"
   subcategory="$(determine_subcategory "$pipeline_name")"
 
   # Required (validated up front by validate_environment).
@@ -350,21 +310,14 @@ customize_generated_app() {
     --set "__NF2OOD_ENV_FILE__=${rendered_env_file}"
   )
 
-  if [[ -n "$image_url" ]]; then
-    customize_args+=(--set "__BANNER_IMAGE_URL__=${image_url}")
-  else
-    customize_args+=(--remove-banner)
-  fi
-
   python3 "$REPO_ROOT/customize_app.py" "$app_dir" "${customize_args[@]}"
 }
 
 generate_app() {
   local input_dir=$1
   local output_dir=$2
-  local image_map_tsv=$3
-  local pipeline_name=$4
-  local pipeline_version=$5
+  local pipeline_name=$3
+  local pipeline_version=$4
   local schema_path app_dir rendered_version base_form base_params generated_form params_template
 
   rendered_version="${pipeline_version//./-}"
@@ -415,7 +368,7 @@ generate_app() {
 
   rm -f "$base_form" "$base_params"
 
-  if ! customize_generated_app "$app_dir" "$pipeline_name" "$pipeline_version" "$image_map_tsv"; then
+  if ! customize_generated_app "$app_dir" "$pipeline_name" "$pipeline_version"; then
     log "WARNING: customize step failed for ${pipeline_name} ${pipeline_version}; skipping."
     rm -rf "$app_dir"
     return 1
@@ -425,7 +378,6 @@ generate_app() {
 parse_args() {
   INPUT_DIR=""
   OUTPUT_DIR=""
-  IMAGE_MAP_TSV=""
   SUBCATEGORY_MAP_TSV=""
   FORCE_OVERWRITE="false"
   DRY_RUN="false"
@@ -442,11 +394,6 @@ parse_args() {
       -o|--output)
         [[ $# -ge 2 ]] || die "Missing value for $1"
         OUTPUT_DIR=$2
-        shift 2
-        ;;
-      -m|--image-map)
-        [[ $# -ge 2 ]] || die "Missing value for $1"
-        IMAGE_MAP_TSV=$2
         shift 2
         ;;
       -s|--subcategory-map)
@@ -512,9 +459,6 @@ main() {
   REPO_ROOT="$(repo_root)"
   TEMPLATE_ROOT="${REPO_ROOT}/nfcore_ood_template"
 
-  if [[ -z "$IMAGE_MAP_TSV" ]]; then
-    IMAGE_MAP_TSV="${REPO_ROOT}/pipeline2image.tsv"
-  fi
   if [[ -z "$SUBCATEGORY_MAP_TSV" ]]; then
     SUBCATEGORY_MAP_TSV="${REPO_ROOT}/pipeline2subcategory.tsv"
   fi
@@ -569,7 +513,7 @@ main() {
 
       # Used as an `if` test so set -e does not abort the whole loop on a
       # per-app failure; the failure is recorded and reported in the summary.
-      if generate_app "$INPUT_DIR" "$OUTPUT_DIR" "$IMAGE_MAP_TSV" "$pipeline_name" "$pipeline_version"; then
+      if generate_app "$INPUT_DIR" "$OUTPUT_DIR" "$pipeline_name" "$pipeline_version"; then
         GENERATED_APPS+=("${pipeline_name} ${pipeline_version}")
       else
         FAILED_APPS+=("${pipeline_name} ${pipeline_version}")

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -33,14 +33,6 @@ end
 ---
 cluster: "__NF2OOD_CLUSTER__"
 form_header: |
-  <!-- NF2OOD_BANNER_START -->
-  <div style="text-align: center; margin-bottom: 20px;">
-    <img src="__BANNER_IMAGE_URL__"
-         alt="__PIPELINE_NAME__"
-         style="max-width: 600px; max-height: 600px; height: auto; margin-bottom: 10px;">
-  </div>
-  <!-- NF2OOD_BANNER_END -->
-
   > **Saved form values**
   >
   > This app automatically saves your form inputs between sessions.

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -1,4 +1,3 @@
-<% nextflow_module_name = "__NF2OOD_MODULE_NAME__".to_s.strip %>
 ---
 cluster: "__NF2OOD_CLUSTER__"
 form_header: |
@@ -24,7 +23,6 @@ attributes:
     unchecked_value: 0
     help: Send an email notification when the Open OnDemand launch job starts.
 
-<% if !nextflow_module_name.empty? %>
   nextflow_version:
     label: Nextflow version
     widget: select
@@ -33,7 +31,6 @@ attributes:
       - ["25.10.3", "25.10.3"]
       - ["25.04.0", "25.04.0"]
     help: Use an older Nextflow version when running previous nf-core pipeline releases.
-<% end %>
 
 <%= File.read("__NF2OOD_PARTITION_YML__").indent(2) %>
 

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -1,35 +1,4 @@
-<%
-require "open3"
-
-nextflow_module_name = "__NF2OOD_MODULE_NAME__".to_s.strip
-nextflow_versions = []
-
-def nextflow_version_sort_key(version)
-  version.scan(/\d+|[A-Za-z]+/).map do |part|
-    if part.match?(/\A\d+\z/)
-      [0, part.to_i]
-    else
-      [1, part.downcase]
-    end
-  end
-end
-
-if !nextflow_module_name.empty?
-  begin
-    module_avail_output, = Open3.capture2(
-      "bash", "-lc", "module -t avail #{nextflow_module_name} 2>&1 || true"
-    )
-
-    nextflow_versions = module_avail_output.lines.filter_map do |line|
-      normalized = line.strip.sub(/\s+\(.*\)\z/, "")
-      match = normalized.match(/\A#{Regexp.escape(nextflow_module_name)}\/(.+)\z/)
-      match && match[1]
-    end.uniq.sort_by { |version| nextflow_version_sort_key(version) }.reverse
-  rescue StandardError
-    nextflow_versions = []
-  end
-end
-%>
+<% nextflow_module_name = "__NF2OOD_MODULE_NAME__".to_s.strip %>
 ---
 cluster: "__NF2OOD_CLUSTER__"
 form_header: |
@@ -55,20 +24,14 @@ attributes:
     unchecked_value: 0
     help: Send an email notification when the Open OnDemand launch job starts.
 
-<% if !nextflow_module_name.empty? && nextflow_versions.any? %>
+<% if !nextflow_module_name.empty? %>
   nextflow_version:
     label: Nextflow version
     widget: select
     options:
-<% nextflow_versions.each do |version| %>
-      - ["<%= version %>", "<%= version %>"]
-<% end %>
-    help: Use an older Nextflow version when running previous nf-core pipeline releases.
-<% elsif !nextflow_module_name.empty? %>
-  nextflow_version:
-    label: Nextflow version
-    widget: text_field
-    required: false
+      - ["26.04.3", "26.04.3"]
+      - ["25.10.3", "25.10.3"]
+      - ["25.04.0", "25.04.0"]
     help: Use an older Nextflow version when running previous nf-core pipeline releases.
 <% end %>
 

--- a/nfcore_ood_template/form.template.erb
+++ b/nfcore_ood_template/form.template.erb
@@ -23,14 +23,7 @@ attributes:
     unchecked_value: 0
     help: Send an email notification when the Open OnDemand launch job starts.
 
-  nextflow_version:
-    label: Nextflow version
-    widget: select
-    options:
-      - ["26.04.3", "26.04.3"]
-      - ["25.10.3", "25.10.3"]
-      - ["25.04.0", "25.04.0"]
-    help: Use an older Nextflow version when running previous nf-core pipeline releases.
+__NEXTFLOW_VERSION_FIELD__
 
 <%= File.read("__NF2OOD_PARTITION_YML__").indent(2) %>
 


### PR DESCRIPTION
## Summary
- remove generated form header images
- bake available Nextflow module versions into generated form.yml.erb files during generation
- bump nf2ood version to 1.3.0 and update the changelog

## Notes
- generated apps now carry a static Nextflow version field derived from the generator host's module environment
- this PR updates release metadata only on dev; no main merge has been performed yet